### PR TITLE
fix: 3 frontmatter/schema mismatches surfaced while running 2.0

### DIFF
--- a/scripts/build_compiled_memory.py
+++ b/scripts/build_compiled_memory.py
@@ -224,7 +224,7 @@ def tracker_hash(path: Path) -> str:
 def shared_meta(tracker_path: Path, posts: List[Dict[str, Any]]) -> Dict[str, Any]:
     level, notes = confidence_level(posts)
     return {
-        "schema_version": "1.0.0",
+        "schema_version": "2.0.0",
         "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "source_tracker": tracker_path.name,
         "source_tracker_hash": tracker_hash(tracker_path),

--- a/scripts/build_voice_distillation.py
+++ b/scripts/build_voice_distillation.py
@@ -533,7 +533,7 @@ def shared_meta(tracker_path: Path, posts: List[Dict[str, Any]]) -> Dict[str, An
     text_count = sum(1 for post in posts if post_text(post))
     metric_count = sum(1 for post in posts if engagement_score(post) > 0)
     return {
-        "schema_version": "1.0.0",
+        "schema_version": "2.0.0",
         "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "source_tracker": tracker_path.name,
         "source_tracker_hash": tracker_hash(tracker_path),

--- a/skills/predict/SKILL.md
+++ b/skills/predict/SKILL.md
@@ -2,7 +2,7 @@
 name: predict
 description: "Estimate likely 24-hour post performance from the user's historical data. Use after the user writes a post and wants a range estimate, upside view, or expectation check."
 version: "2.0.0"
-allowed-tools: Read, Write, Edit, Grep, Glob
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash
 ---
 
 # AK-Threads-Booster Performance Prediction Module (M7)

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -2,7 +2,7 @@
 name: topics
 description: "Mine insights from comments and historical data to recommend the next worthwhile topics. Trigger words: 'topics', 'topic', '選題', '寫什麼'."
 version: "2.0.0"
-allowed-tools: Read, Grep, Glob, WebSearch
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash, WebSearch
 ---
 
 # AK-Threads-Booster Topic Recommendation Module


### PR DESCRIPTION
While running every command in 2.0 against my own tracker, I hit three small mismatches between what the SKILL.md / schema docs say and what the code does. None block the skill from working most of the time, but each one trips a specific scenario silently. Each commit is a few lines.

## Fix 1 — `/topics` frontmatter is missing `Write` and `Bash`

`skills/topics/SKILL.md` body mandates two operations the frontmatter forbids:

- Step 3.5 (line 141): *"Each `/topics` run must append one JSON line per checked candidate to `threads_freshness.log`"* — needs `Write`/`Edit`.
- Step 2.5 / line 107: `python scripts/build_compiled_memory.py --tracker ./threads_daily_tracker.json` — needs `Bash`.

What I observed: my `/topics` run produced recommendations but `threads_freshness.log` got no audit line — and `/review` Step 6.5 hygiene check then flagged the run as missing audit trail. Compiled memory wasn't rebuilt either, so the next `/analyze` ran on stale `cluster_wiki.json`.

## Fix 2 — `/predict` frontmatter is missing `Bash`

`skills/predict/SKILL.md:203` says:

> If `/predict` writes a pending placeholder or updates `prediction_snapshot`, rebuild compiled memory with `scripts/build_compiled_memory.py --tracker ./threads_daily_tracker.json`.

Frontmatter is `Read, Write, Edit, Grep, Glob` — no `Bash`. After my `/predict` ran on a draft and persisted a `prediction_snapshot`, `compiled/` was left stale; next consumer skill saw `source_tracker_hash` mismatch with the mutated tracker and fell back to legacy paths.

## Fix 3 — Compiled-memory `schema_version` drift

`templates/compiled-memory-schema.json:3` declares `_meta.schema_version: "2.0.0"` (set in `d450614 Release AK-Threads-Booster 2.0`), but both builders write `"1.0.0"`:

- `scripts/build_compiled_memory.py:227`
- `scripts/build_voice_distillation.py:536`

I tried `runtime.compiled_memory: require_fresh` (per `knowledge/_shared/runtime-budget.md`) and found that any consumer that gates on schema match will reject every build forever — silently downgrading to the tracker-only fallback the low-token runtime is meant to avoid.

Bumped both builder outputs to `"2.0.0"` to match the schema doc and the v2.0 release. The compiled data shape itself is unchanged; only the `_meta.schema_version` string moves.

If your intent is the opposite — keep builder at `1.0.0` and revert the schema doc — happy to invert. The drift itself is the bug.

---

## Independence

Independent of #5 (`feat/persistence-hardening` — the FAILSAFE / cp950 / ISO-sort PR coming alongside this one). Either PR can merge first; no ordering requirement.

## Why open as PRs rather than an issue

Each fix matches a contract already documented in this repo (the SKILL.md body, the schema doc, the FAILSAFE policy). Treating them as bug fixes rather than feature proposals — happy to close immediately if you prefer to address internally.