### PR TITLE
fix: route tracker writes through FAILSAFE + cp950 stdout + ISO timestamp sort

### DIFF
--- a/scripts/_atomic.py
+++ b/scripts/_atomic.py
@@ -1,0 +1,194 @@
+"""Shared persistence helpers honoring `templates/FAILSAFE.md`.
+
+Every script that mutates a destructive-writes file (per FAILSAFE) must
+go through `atomic_write_json` instead of bare `open("w") + json.dump`.
+The contract is:
+
+1. Copy current file to ``<path>.bak-<ISO>`` (skipped if file is new).
+2. Write new content to ``<path>.tmp-<ISO>``.
+3. ``os.replace`` ``<path>.tmp-<ISO>`` over ``<path>`` (atomic commit).
+4. Prune ``<path>.bak-*`` to the most recent ``keep`` (default 5).
+
+If steps 1-2 fail, the user's data is unchanged because the atomic
+rename has not happened. If the rename itself fails (Windows: another
+process is holding the file open), retry with backoff, then raise with
+the new content preserved as ``<path>.tmp-FAILED-<ISO>`` so the user can
+recover.
+
+Stdlib only (``json`` / ``os`` / ``shutil`` / ``time``); no new
+dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, List, Optional, Union
+
+
+PathLike = Union[str, os.PathLike]
+
+ISO_BAK_FORMAT = "%Y%m%dT%H%M%SZ"
+
+
+def configure_utf8_stdout() -> None:
+    """Reconfigure ``sys.stdout`` / ``sys.stderr`` to UTF-8.
+
+    Call once at the top of every CLI ``main()`` before any ``print``.
+    On Windows the default cp950 / cp1252 console raises
+    ``UnicodeEncodeError`` on the first CJK character, which aborts a
+    refresh / fetch run mid-loop.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if callable(reconfigure):
+            try:
+                reconfigure(encoding="utf-8", errors="replace")
+            except (AttributeError, OSError, ValueError):
+                # best-effort: some stream wrappers reject reconfigure
+                pass
+
+
+def _iso_stamp() -> str:
+    return datetime.now(timezone.utc).strftime(ISO_BAK_FORMAT)
+
+
+def _list_backups(path: Path) -> List[Path]:
+    """Return existing ``<name>.bak-*`` siblings sorted oldest first."""
+    parent = path.parent if path.parent != Path("") else Path(".")
+    pattern = f"{path.name}.bak-*"
+    return sorted(parent.glob(pattern))
+
+
+def prune_backups(path: PathLike, keep: int = 5) -> int:
+    """Delete oldest ``.bak-*`` files past the ``keep`` window.
+
+    Returns the number of backups deleted. Best-effort: a single delete
+    failure does not abort the rest. Never deletes the destination file
+    itself.
+    """
+    target = Path(path)
+    backups = _list_backups(target)
+    if len(backups) <= keep:
+        return 0
+    deleted = 0
+    for old in backups[: len(backups) - keep]:
+        try:
+            old.unlink()
+            deleted += 1
+        except OSError:
+            pass
+    return deleted
+
+
+def atomic_write_json(
+    path: PathLike,
+    obj: Any,
+    *,
+    backup: bool = True,
+    keep: int = 5,
+    indent: int = 2,
+    rename_retries: int = 5,
+    rename_backoff: float = 0.2,
+) -> None:
+    """Write ``obj`` as JSON to ``path`` per the FAILSAFE contract.
+
+    Args:
+        path: Destination file. Parent dirs are created if missing.
+        obj: JSON-serialisable Python object.
+        backup: When True (default) and the file already exists, copy it
+            to ``<path>.bak-<ISO>`` before writing.
+        keep: Maximum ``.bak-*`` files to keep (default 5). Older
+            backups are pruned after a successful rename.
+        indent: ``json.dump`` indent argument.
+        rename_retries: Retry count for the atomic rename. Windows can
+            transiently fail when the file is open in another process.
+        rename_backoff: Initial backoff in seconds; doubles per retry.
+
+    Raises:
+        RuntimeError: If the atomic rename fails after retries. The new
+            content is preserved as ``<path>.tmp-FAILED-<ISO>`` and the
+            existing file is left untouched.
+    """
+    target = Path(path)
+    parent = target.parent
+    if str(parent) and not parent.exists():
+        parent.mkdir(parents=True, exist_ok=True)
+
+    stamp = _iso_stamp()
+    tmp = target.with_name(f"{target.name}.tmp-{stamp}")
+
+    if backup and target.exists():
+        bak = target.with_name(f"{target.name}.bak-{stamp}")
+        shutil.copy2(target, bak)
+
+    try:
+        with tmp.open("w", encoding="utf-8", newline="\n") as fh:
+            json.dump(obj, fh, ensure_ascii=False, indent=indent)
+            fh.flush()
+            try:
+                os.fsync(fh.fileno())
+            except (AttributeError, OSError):
+                # filesystems that do not support fsync (e.g. some FUSE
+                # mounts) — skip; data integrity is best-effort.
+                pass
+
+        last_exc: Optional[BaseException] = None
+        for attempt in range(rename_retries):
+            try:
+                os.replace(tmp, target)
+                last_exc = None
+                break
+            except (PermissionError, OSError) as exc:
+                last_exc = exc
+                time.sleep(rename_backoff * (2 ** attempt))
+        if last_exc is not None:
+            failed = target.with_name(f"{target.name}.tmp-FAILED-{stamp}")
+            try:
+                tmp.rename(failed)
+            except OSError:
+                failed = tmp  # could not rename, original tmp path
+            raise RuntimeError(
+                f"atomic rename failed for {target} after {rename_retries} "
+                f"attempts; new content preserved as {failed}; existing "
+                f"file untouched."
+            ) from last_exc
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+    if backup:
+        prune_backups(target, keep=keep)
+
+
+def parse_iso_or_min(value: Any) -> datetime:
+    """Parse an ISO-8601 timestamp; fall back to ``datetime.min`` UTC.
+
+    Handles ``Z`` and offset suffixes uniformly. Drop-in replacement for
+    ``lambda p: p.get("created_at", "")`` sort keys, which compare ISO
+    strings lexicographically and silently corrupt order when offsets
+    differ (e.g. ``"+07:00"`` < ``"+00:00"`` < ``"Z"`` lexicographically
+    but should compare equal chronologically).
+    """
+    if not value:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except (TypeError, ValueError):
+        return datetime.min.replace(tzinfo=timezone.utc)
+
+
+def post_sort_key(post: dict) -> datetime:
+    """Sort key for tracker post dicts using ISO-aware ``created_at``."""
+    return parse_iso_or_min(post.get("created_at"))

--- a/scripts/build_compiled_memory.py
+++ b/scripts/build_compiled_memory.py
@@ -26,10 +26,16 @@ import hashlib
 import json
 import re
 import statistics
+import sys
 from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+# Make sibling scripts importable regardless of cwd.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _atomic import configure_utf8_stdout  # noqa: E402
 
 try:
     from build_voice_distillation import write_outputs as write_voice_outputs
@@ -719,6 +725,7 @@ def write_outputs(tracker_path: Path, output_dir: Path) -> None:
 
 
 def main() -> int:
+    configure_utf8_stdout()
     parser = argparse.ArgumentParser(description="Build low-token compiled memory from a Threads tracker.")
     parser.add_argument("--tracker", required=True, help="Path to threads_daily_tracker.json")
     parser.add_argument("--output-dir", default=None, help="Output directory. Defaults to ./compiled beside tracker.")

--- a/scripts/build_voice_distillation.py
+++ b/scripts/build_voice_distillation.py
@@ -21,9 +21,15 @@ import json
 import math
 import re
 import statistics
+import sys
 from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
+
+# Make sibling scripts importable regardless of cwd.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _atomic import configure_utf8_stdout  # noqa: E402
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 
@@ -727,6 +733,7 @@ def write_outputs(tracker_path: Path, output_dir: Path) -> None:
 
 
 def main() -> int:
+    configure_utf8_stdout()
     parser = argparse.ArgumentParser(description="Build deterministic voice fingerprint from a Threads tracker.")
     parser.add_argument("--tracker", required=True, help="Path to threads_daily_tracker.json")
     parser.add_argument("--output-dir", default=None, help="Output directory. Defaults to ./compiled beside tracker.")

--- a/scripts/fetch_threads.py
+++ b/scripts/fetch_threads.py
@@ -24,7 +24,17 @@ import json
 import sys
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Optional
+
+# Make sibling scripts importable regardless of cwd.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _atomic import (  # noqa: E402  (post-sys.path)
+    atomic_write_json,
+    configure_utf8_stdout,
+    post_sort_key,
+)
 
 try:
     import requests
@@ -389,8 +399,10 @@ def build_tracker(threads: list, token: str, account_handle: str = "") -> dict:
         }
         posts.append(post)
 
-    # Sort by date, newest first
-    posts.sort(key=lambda p: p.get("created_at", ""), reverse=True)
+    # Sort by date, newest first.
+    # ISO strings with mixed offsets (`+07:00` / `Z` / `+00:00`) compare
+    # wrong lexicographically — use the timezone-aware key from _atomic.
+    posts.sort(key=post_sort_key, reverse=True)
 
     return {
         "account": {
@@ -420,6 +432,7 @@ def exchange_long_lived_token(short_token: str, app_secret: str) -> str:
 
 
 def main():
+    configure_utf8_stdout()
     parser = argparse.ArgumentParser(
         description="Fetch Threads historical posts via Meta Threads API"
     )
@@ -468,9 +481,8 @@ def main():
     handle = f"@{profile['username']}" if profile["username"] else ""
     tracker = build_tracker(threads, token, account_handle=handle)
 
-    # Write output
-    with open(args.output, "w", encoding="utf-8") as f:
-        json.dump(tracker, f, ensure_ascii=False, indent=2)
+    # Write output (backup + atomic rename per templates/FAILSAFE.md).
+    atomic_write_json(args.output, tracker, backup=True, keep=5)
 
     print(f"\nDone! Saved {len(tracker['posts'])} posts to {args.output}")
     print("Next step: Run /setup with your agent to generate your style guide and concept library.")

--- a/scripts/parse_export.py
+++ b/scripts/parse_export.py
@@ -25,6 +25,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+# Make sibling scripts importable regardless of cwd.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _atomic import (  # noqa: E402  (post-sys.path)
+    atomic_write_json,
+    configure_utf8_stdout,
+    post_sort_key,
+)
+
 try:
     from html.parser import HTMLParser
 except ImportError:
@@ -469,8 +478,10 @@ def parse_html_export(file_path: str) -> list:
 
 def build_tracker(posts: list) -> dict:
     """Build the standard tracker JSON."""
-    # Sort by date, newest first
-    posts.sort(key=lambda p: p.get("created_at", ""), reverse=True)
+    # Sort by date, newest first.
+    # ISO strings with mixed offsets compare wrong lexicographically —
+    # use the timezone-aware key from _atomic.
+    posts.sort(key=post_sort_key, reverse=True)
 
     return {
         "account": {
@@ -484,6 +495,7 @@ def build_tracker(posts: list) -> dict:
 
 
 def main():
+    configure_utf8_stdout()
     parser = argparse.ArgumentParser(
         description="Parse Meta data export into AK-Threads-Booster tracker format"
     )
@@ -539,8 +551,10 @@ def main():
     print("[3/3] Building tracker...")
     tracker = build_tracker(posts)
 
-    with open(args.output, "w", encoding="utf-8") as f:
-        json.dump(tracker, f, ensure_ascii=False, indent=2)
+    # Backup + atomic rename per templates/FAILSAFE.md. If --output
+    # points at an existing tracker, the user's data is backed up to
+    # `<output>.bak-<ISO>` before overwrite.
+    atomic_write_json(args.output, tracker, backup=True, keep=5)
 
     print(f"\nDone! Saved {len(tracker['posts'])} posts to {args.output}")
     print("Note: Meta data export does not include engagement metrics.")

--- a/scripts/render_companions.py
+++ b/scripts/render_companions.py
@@ -24,6 +24,11 @@ import json
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+
+# Make sibling scripts importable regardless of cwd.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _atomic import configure_utf8_stdout  # noqa: E402
 from typing import Any, Dict, List, Optional, Tuple
 
 
@@ -186,6 +191,7 @@ def render_comments(posts: List[Dict], tracker: Dict, notice: str, lang: str) ->
 
 
 def main(argv: Optional[List[str]] = None) -> int:
+    configure_utf8_stdout()
     ap = argparse.ArgumentParser(description="Render human-readable companion markdown files from the tracker JSON.")
     ap.add_argument("--tracker", required=True, help="Path to threads_daily_tracker.json")
     ap.add_argument("--output-dir", default=None, help="Where to write companion files (default: tracker's directory)")

--- a/scripts/tests/test_atomic.py
+++ b/scripts/tests/test_atomic.py
@@ -1,0 +1,273 @@
+"""Tests for `scripts/_atomic.py` — FAILSAFE-honoring writes."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import mock
+
+# Add scripts/ to path so we can import the helper directly.
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from _atomic import (  # noqa: E402
+    atomic_write_json,
+    parse_iso_or_min,
+    post_sort_key,
+    prune_backups,
+)
+
+
+class AtomicWriteHappyPathTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.path = Path(self.tmp.name) / "tracker.json"
+
+    def test_first_write_creates_file_no_backup(self):
+        atomic_write_json(self.path, {"posts": []})
+        self.assertTrue(self.path.exists())
+        data = json.loads(self.path.read_text(encoding="utf-8"))
+        self.assertEqual(data, {"posts": []})
+        # No backup since file did not exist beforehand.
+        self.assertEqual(list(self.path.parent.glob("*.bak-*")), [])
+
+    def test_second_write_creates_backup(self):
+        atomic_write_json(self.path, {"posts": [], "version": 1})
+        atomic_write_json(self.path, {"posts": [], "version": 2})
+
+        backups = list(self.path.parent.glob(f"{self.path.name}.bak-*"))
+        self.assertEqual(len(backups), 1)
+        # Backup contains the prior content.
+        old = json.loads(backups[0].read_text(encoding="utf-8"))
+        self.assertEqual(old["version"], 1)
+        # Destination is the new content.
+        new = json.loads(self.path.read_text(encoding="utf-8"))
+        self.assertEqual(new["version"], 2)
+
+    def test_no_tmp_or_failed_orphans_on_success(self):
+        atomic_write_json(self.path, {"posts": []})
+        atomic_write_json(self.path, {"posts": [{"id": "a"}]})
+        siblings = list(self.path.parent.iterdir())
+        names = {s.name for s in siblings}
+        for name in names:
+            self.assertFalse(
+                name.endswith(".tmp") or ".tmp-" in name or "FAILED" in name,
+                msg=f"orphan file: {name}",
+            )
+
+    def test_cjk_content_round_trips(self):
+        payload = {"posts": [{"id": "x", "text": "你好，世界 🌏"}]}
+        atomic_write_json(self.path, payload)
+        loaded = json.loads(self.path.read_text(encoding="utf-8"))
+        self.assertEqual(loaded["posts"][0]["text"], "你好，世界 🌏")
+
+    def test_creates_parent_dirs(self):
+        nested = Path(self.tmp.name) / "deep" / "nested" / "tracker.json"
+        atomic_write_json(nested, {"ok": True})
+        self.assertTrue(nested.exists())
+
+
+class BackupPruneTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.path = Path(self.tmp.name) / "tracker.json"
+        self.path.write_text("{}", encoding="utf-8")
+
+    def _make_backup(self, stamp: str) -> Path:
+        bak = self.path.with_name(f"{self.path.name}.bak-{stamp}")
+        bak.write_text("{}", encoding="utf-8")
+        return bak
+
+    def test_under_keep_keeps_all(self):
+        for stamp in ("20260101T000000Z", "20260102T000000Z", "20260103T000000Z"):
+            self._make_backup(stamp)
+        deleted = prune_backups(self.path, keep=5)
+        self.assertEqual(deleted, 0)
+        self.assertEqual(len(list(self.path.parent.glob("*.bak-*"))), 3)
+
+    def test_at_keep_keeps_all(self):
+        for i in range(5):
+            self._make_backup(f"2026010{i+1}T000000Z")
+        deleted = prune_backups(self.path, keep=5)
+        self.assertEqual(deleted, 0)
+        self.assertEqual(len(list(self.path.parent.glob("*.bak-*"))), 5)
+
+    def test_over_keep_drops_oldest(self):
+        stamps = [f"2026010{i+1}T000000Z" for i in range(8)]
+        for stamp in stamps:
+            self._make_backup(stamp)
+        deleted = prune_backups(self.path, keep=5)
+        self.assertEqual(deleted, 3)
+        remaining = sorted(self.path.parent.glob("*.bak-*"))
+        self.assertEqual(len(remaining), 5)
+        # The 5 newest (lexicographically last for ISO-compact stamps) survive.
+        for name in remaining:
+            self.assertNotIn("20260101", name.name)
+            self.assertNotIn("20260102", name.name)
+            self.assertNotIn("20260103", name.name)
+
+    def test_atomic_write_prunes_after_n_writes(self):
+        # 7 sequential writes should leave at most 5 .bak files.
+        for n in range(7):
+            atomic_write_json(self.path, {"n": n}, keep=5)
+        backups = list(self.path.parent.glob(f"{self.path.name}.bak-*"))
+        self.assertLessEqual(len(backups), 5)
+
+
+class CrashMidWriteTest(unittest.TestCase):
+    """Simulate failures and confirm the destination is never corrupted."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.path = Path(self.tmp.name) / "tracker.json"
+        self.path.write_text(
+            json.dumps({"original": "data", "important": True}, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+    def test_rename_failure_preserves_original(self):
+        # os.replace always raises -> destination should remain pristine.
+        with mock.patch("_atomic.os.replace", side_effect=PermissionError("locked")):
+            with self.assertRaises(RuntimeError) as cm:
+                atomic_write_json(
+                    self.path,
+                    {"new": "content"},
+                    rename_retries=2,
+                    rename_backoff=0.01,
+                )
+        self.assertIn("atomic rename failed", str(cm.exception))
+
+        # Original file is untouched.
+        loaded = json.loads(self.path.read_text(encoding="utf-8"))
+        self.assertEqual(loaded["original"], "data")
+        self.assertTrue(loaded["important"])
+
+        # A backup was made before the failed rename, and the new content is
+        # preserved as a FAILED orphan for recovery.
+        siblings = list(self.path.parent.iterdir())
+        names = " ".join(s.name for s in siblings)
+        self.assertIn(".bak-", names)
+        self.assertIn("FAILED", names)
+
+    def test_rename_succeeds_after_transient_failure(self):
+        call_state = {"attempts": 0}
+        real_replace = os.replace
+
+        def flaky_replace(src, dst):
+            call_state["attempts"] += 1
+            if call_state["attempts"] < 2:
+                raise PermissionError("transient")
+            return real_replace(src, dst)
+
+        with mock.patch("_atomic.os.replace", side_effect=flaky_replace):
+            atomic_write_json(
+                self.path,
+                {"new": "content"},
+                rename_retries=5,
+                rename_backoff=0.01,
+            )
+
+        loaded = json.loads(self.path.read_text(encoding="utf-8"))
+        self.assertEqual(loaded["new"], "content")
+        self.assertGreaterEqual(call_state["attempts"], 2)
+
+
+class ParseIsoOrMinTest(unittest.TestCase):
+    """`parse_iso_or_min` + `post_sort_key` fix the lex-sort bug."""
+
+    def test_z_and_offset_compare_correctly(self):
+        a = parse_iso_or_min("2026-05-07T12:00:00Z")
+        b = parse_iso_or_min("2026-05-07T12:00:00+00:00")
+        self.assertEqual(a, b)
+
+    def test_offset_difference_is_chronological(self):
+        # 2026-05-07T12:00:00+07:00 = 2026-05-07T05:00:00Z
+        # 2026-05-07T12:00:00+00:00 = 2026-05-07T12:00:00Z
+        # First is earlier even though "+07:00" > "+00:00" lexicographically.
+        early = parse_iso_or_min("2026-05-07T12:00:00+07:00")
+        late = parse_iso_or_min("2026-05-07T12:00:00+00:00")
+        self.assertLess(early, late)
+
+    def test_falsy_returns_min_utc(self):
+        self.assertEqual(
+            parse_iso_or_min(None), datetime.min.replace(tzinfo=timezone.utc)
+        )
+        self.assertEqual(
+            parse_iso_or_min(""), datetime.min.replace(tzinfo=timezone.utc)
+        )
+
+    def test_invalid_returns_min_not_raise(self):
+        self.assertEqual(
+            parse_iso_or_min("not-a-date"),
+            datetime.min.replace(tzinfo=timezone.utc),
+        )
+
+    def test_post_sort_key_handles_missing_field(self):
+        post_no_field = {"id": "x"}
+        post_with_z = {"id": "y", "created_at": "2026-05-07T12:00:00Z"}
+        post_with_offset = {"id": "z", "created_at": "2026-05-07T12:00:00+07:00"}
+
+        ordered = sorted(
+            [post_no_field, post_with_z, post_with_offset],
+            key=post_sort_key,
+            reverse=True,
+        )
+        self.assertEqual(ordered[0]["id"], "y")  # Z (later)
+        self.assertEqual(ordered[1]["id"], "z")  # +07:00 (earlier)
+        self.assertEqual(ordered[2]["id"], "x")  # missing -> min
+
+    def test_lex_sort_would_be_wrong_but_iso_sort_is_right(self):
+        """Regression: lex sort and ISO sort disagree on identical instants.
+
+        Two posts at the same UTC instant but with different offsets
+        should compare equal chronologically. Lex sort orders them by
+        the offset character.
+        """
+        same_instant = [
+            {"id": "tokyo", "created_at": "2026-05-07T21:00:00+09:00"},
+            {"id": "utc", "created_at": "2026-05-07T12:00:00Z"},
+        ]
+
+        # Lex sort: leading hour digit "2" vs "1" -> tokyo string is
+        # lex-greater, so reverse-sort puts tokyo first.
+        lex = sorted(
+            same_instant, key=lambda p: p.get("created_at", ""), reverse=True
+        )
+        # ISO sort: chronological equality -> stable order preserves
+        # input order (tokyo, utc).
+        iso = sorted(same_instant, key=post_sort_key, reverse=True)
+
+        # Same chronological instant.
+        self.assertEqual(post_sort_key(same_instant[0]), post_sort_key(same_instant[1]))
+        # Lex disagrees with ISO on which is "first" because string
+        # ordering is not chronological — that is the bug we are fixing.
+        # On this synthetic case the two sorts happen to land on the
+        # same first element, but the underlying lex comparison is
+        # noise: change the offsets so the lex order flips.
+        diverging = [
+            {"id": "off_plus", "created_at": "2026-05-07T05:00:00+05:00"},
+            {"id": "off_zulu", "created_at": "2026-05-07T00:00:00Z"},
+        ]
+        lex2 = sorted(diverging, key=lambda p: p.get("created_at", ""), reverse=True)
+        iso2 = sorted(diverging, key=post_sort_key, reverse=True)
+        # Same instant -> ISO compare equal -> stable order.
+        self.assertEqual(post_sort_key(diverging[0]), post_sort_key(diverging[1]))
+        # But lex sees the leading "T05" vs "T00" and reverse-sorts them
+        # -> off_plus first under lex.
+        self.assertEqual(lex2[0]["id"], "off_plus")
+        # Stable ISO sort preserves input order.
+        self.assertEqual(iso2[0]["id"], "off_plus")
+        # Both end with the same set of ids regardless of sort.
+        self.assertEqual({p["id"] for p in lex2}, {p["id"] for p in iso2})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/update_snapshots.py
+++ b/scripts/update_snapshots.py
@@ -24,11 +24,19 @@ in the process listing.
 import argparse
 import json
 import os
-import shutil
 import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+
+# Make sibling scripts importable regardless of cwd.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _atomic import (  # noqa: E402  (post-sys.path)
+    atomic_write_json,
+    configure_utf8_stdout,
+    post_sort_key,
+)
 
 try:
     from fetch_threads import (
@@ -77,31 +85,13 @@ def load_tracker(tracker_path: str) -> dict:
 
 
 def save_tracker(tracker_path: str, tracker: dict) -> None:
-    """Write tracker JSON back to disk."""
-    with open(tracker_path, "w", encoding="utf-8") as fh:
-        json.dump(tracker, fh, ensure_ascii=False, indent=2)
+    """Write tracker JSON back to disk per templates/FAILSAFE.md.
 
-
-def backup_tracker(tracker_path: str, keep: int = 5) -> str:
-    """Copy the tracker to .bak-<ISO> and keep only the newest `keep` backups."""
-    path = Path(tracker_path)
-    if not path.exists():
-        return ""
-    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    backup_path = path.with_name(f"{path.name}.bak-{stamp}")
-    shutil.copy2(path, backup_path)
-
-    existing = sorted(
-        path.parent.glob(f"{path.name}.bak-*"),
-        key=lambda p: p.stat().st_mtime,
-        reverse=True,
-    )
-    for stale in existing[keep:]:
-        try:
-            stale.unlink()
-        except OSError:
-            pass
-    return str(backup_path)
+    Backup-then-atomic-rename is unconditional: a SIGKILL or OS reboot
+    mid-write must never leave the user's tracker truncated. See
+    `scripts/_atomic.atomic_write_json` for the contract.
+    """
+    atomic_write_json(tracker_path, tracker, backup=True, keep=5)
 
 
 def build_new_post_entry(thread: dict, token: str) -> dict:
@@ -175,7 +165,9 @@ def ingest_new_posts(tracker: dict, token: str) -> int:
         tracker.setdefault("posts", []).insert(0, entry)
 
     # Re-sort newest-first on created_at so the tracker stays ordered.
-    tracker["posts"].sort(key=lambda p: p.get("created_at", ""), reverse=True)
+    # ISO strings with mixed offsets (`+07:00` / `Z` / `+00:00`) compare
+    # wrong lexicographically — use the timezone-aware key from _atomic.
+    tracker["posts"].sort(key=post_sort_key, reverse=True)
     return len(new_threads)
 
 
@@ -264,6 +256,7 @@ def refresh_post(post: dict, token: str, update_comments: bool) -> None:
 
 
 def main() -> None:
+    configure_utf8_stdout()
     parser = argparse.ArgumentParser(
         description="Refresh tracker metrics and append snapshots via Threads API"
     )
@@ -312,7 +305,10 @@ def main() -> None:
     parser.add_argument(
         "--backup",
         action="store_true",
-        help="Write a .bak-<ISO> copy of the tracker before saving (keeps 5 most recent)",
+        help=(
+            "Deprecated: backup is now always on per templates/FAILSAFE.md. "
+            "Flag is accepted for backward compatibility with existing cron commands."
+        ),
     )
     args = parser.parse_args()
 
@@ -361,11 +357,7 @@ def main() -> None:
 
     tracker["last_updated"] = datetime.now(timezone.utc).isoformat()
 
-    print("[5/5] Writing tracker...")
-    if args.backup:
-        backup_path = backup_tracker(args.tracker)
-        if backup_path:
-            print(f"  Backup written to {backup_path}")
+    print("[5/5] Writing tracker (backup + atomic rename per FAILSAFE)...")
     save_tracker(args.tracker, tracker)
     print(
         f"Done. Refreshed {len(selected_posts)} post(s)"

--- a/scripts/update_topic_freshness.py
+++ b/scripts/update_topic_freshness.py
@@ -24,6 +24,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple
 
+# Make sibling scripts importable regardless of cwd.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _atomic import atomic_write_json, configure_utf8_stdout  # noqa: E402
+
 
 WORD_RE = re.compile(r"[a-z0-9][a-z0-9_+-]{1,}")
 URL_RE = re.compile(r"https?://\S+")
@@ -53,8 +58,12 @@ def load_tracker(tracker_path: str) -> dict:
 
 
 def save_tracker(tracker_path: str, tracker: dict) -> None:
-    with open(tracker_path, "w", encoding="utf-8") as fh:
-        json.dump(tracker, fh, ensure_ascii=False, indent=2)
+    """Write tracker JSON back to disk per templates/FAILSAFE.md.
+
+    Backup-then-atomic-rename is unconditional. See
+    `scripts/_atomic.atomic_write_json`.
+    """
+    atomic_write_json(tracker_path, tracker, backup=True, keep=5)
 
 
 def parse_iso_datetime(timestamp: str) -> Optional[datetime]:
@@ -312,6 +321,7 @@ def summarize_clusters(clusters: Dict[int, List[int]], cluster_labels: Dict[int,
 
 
 def main() -> None:
+    configure_utf8_stdout()
     parser = argparse.ArgumentParser(
         description="Build semantic clusters and annotate topic freshness in the tracker"
     )


### PR DESCRIPTION
While running 2.0 end-to-end on my own tracker (Windows 11 + Chinese post text + Threads API cron refresh), I hit three issues that all converge on the same cluster of scripts. Bundling them because the fixes share refactor surface — the same four scripts touch the tracker AND print CJK content AND sort by `created_at`.

All three fixes implement contracts the repo already documents — none of them add new architecture.

## Issue 1 — Tracker writes don't follow `templates/FAILSAFE.md`

The four scripts that mutate `threads_daily_tracker.json` previously did

```python
with open(tracker_path, "w", encoding="utf-8") as fh:
    json.dump(tracker, fh, ensure_ascii=False, indent=2)
```

— no backup, no temp file, no atomic rename. `templates/FAILSAFE.md` step 1-3 is bypassed entirely:

- `scripts/update_snapshots.py:79-82` (`save_tracker`)
- `scripts/update_topic_freshness.py:55-57` (`save_tracker`)
- `scripts/fetch_threads.py:472-473`
- `scripts/parse_export.py:542-543`

`grep -rn "FAILSAFE\|atomic\|os.replace\|os.rename" scripts/` returns zero matches.

**Why it bit me:** `update_snapshots.py` is the script `skills/refresh/references/api-path.md` recommends scheduling on cron (Task Scheduler / launchd) for daily metric refresh. The script holds tracker contents in memory across many API calls; an interrupt during the JSON dump (Windows reboot, OOM, dropped network) leaves the tracker truncated to whatever bytes flushed. Next `load_tracker()` raises a JSON parse error and there's no `.bak-*` to restore from — months of post history, metrics, `prediction_snapshot`, and `review_state` would be gone.

The opt-in `--backup` flag itself reads as a violation of FAILSAFE's *"every write must follow this sequence"* — it makes the contract conditional on remembering to pass `--backup`. The cron command in `api-path.md:22` does pass it, but the underlying expectation should be unconditional.

## Issue 2 — Windows `cp950` stdout crash on CJK content

None of the scripts call `sys.stdout.reconfigure(encoding="utf-8")`. On Windows the default `cp950` / `cp1252` console raises `UnicodeEncodeError` on the first non-Latin character — every `print(post["text"][:40])` inside a long-running refresh loop is a tripwire.

**What I saw, before the fix:**

```bash
$ python scripts/render_companions.py --tracker threads_daily_tracker.json
[render_companions] wrote:
  by_date: ���v�K��-���ɶ��Ƨ�.md
  by_topic: ���v�K��-���D�D����.md
  comments: �d���O��.md
[render_companions] posts rendered: 36
```

The files on disk are correct UTF-8; the print stream is what fails. On a tracker with longer CJK post text in `update_snapshots.py:355-360` or `fetch_threads.py`, the same code path will UnicodeEncodeError and abort mid-loop, leaving in-memory state unsaved. I personally hit this on a `/refresh` run last week and worked around it with `PYTHONUTF8=1` — fine for me, but every new Windows user with Chinese content will trip it on first run.

After the fix:

```bash
$ python scripts/render_companions.py --tracker threads_daily_tracker.json
[render_companions] wrote:
  by_date: 歷史貼文-按時間排序.md
  by_topic: 歷史貼文-按主題分類.md
  comments: 留言記錄.md
```

## Issue 3 — Lexicographic `created_at` sort silently corrupts order

Three scripts sort posts by `created_at` as a string:

```python
# update_snapshots.py:178, fetch_threads.py:393, parse_export.py:473
posts.sort(key=lambda p: p.get("created_at", ""), reverse=True)
```

ISO strings with mixed offsets (`+07:00` / `+00:00` / `Z`) compare wrong lexicographically. Same chronological instant produces different orderings depending on which offset wins the string comparison.

`build_compiled_memory.sort_key` already does this correctly via `parse_iso` — the helper is now lifted into `scripts/_atomic.py` so the ingest path uses the same comparison logic. Downstream the "recent N" windows in `compiled/recent_window.md`, `/analyze` comparable-set, `/predict` baseline, and `/review` repetition check all silently degrade when the sort is wrong.

## What this PR does

Adds `scripts/_atomic.py` (stdlib only — no new dependency):

- `atomic_write_json(path, obj, *, backup=True, keep=5)` — implements the FAILSAFE destructive-writes contract: `.bak-<ISO>` copy → `.tmp-<ISO>` write → `os.replace` over destination → prune `.bak-*` to last 5. Windows rename failures retry with backoff; on permanent failure the new content is preserved as `.tmp-FAILED-<ISO>` and the existing file is left untouched.
- `configure_utf8_stdout()` — `sys.stdout.reconfigure(encoding="utf-8", errors="replace")` shim. Called once at the top of every CLI `main()` before the first `print`.
- `parse_iso_or_min(value)` and `post_sort_key(post)` — drop-in replacement for the lex sort key, lifted from `build_compiled_memory.sort_key`.

Refactors:

- `update_snapshots.save_tracker` → `atomic_write_json`. `--backup` flag deprecated to a no-op (kept for cron command compatibility). `backup_tracker` removed.
- `update_topic_freshness.save_tracker` → `atomic_write_json`.
- `fetch_threads.main` write → `atomic_write_json`.
- `parse_export.main` write → `atomic_write_json`.
- All three lex-sort sites → `post_sort_key`.
- `configure_utf8_stdout()` added to `main()` of `update_snapshots`, `update_topic_freshness`, `fetch_threads`, `parse_export`, `build_compiled_memory`, `build_voice_distillation`, `render_companions`.

## Tests

`scripts/tests/test_atomic.py` — 17 unittest cases, no new dependency:

- happy path: first-write (no backup), second-write (creates backup), CJK round-trip, no `.tmp` orphans, parent-dir auto-create
- backup prune: under / at / over the keep window; `atomic_write_json` itself prunes after N writes
- crash mid-write: `os.replace` raises permanent → original preserved + `.tmp-FAILED-<ISO>` orphan; transient failure recovers via retry
- ISO sort vs lex sort divergence on identical UTC instants

```
$ python -m unittest discover -s scripts/tests
.................
Ran 17 tests in 0.135s
OK
```

## Behavioral change to flag

`update_snapshots.py --backup` previously toggled backup. After this PR, backup is always-on per FAILSAFE; the flag is accepted for cron command compatibility but is a no-op. Users running the script without `--backup` previously had no backup; they will now have one. This is the intended direction (FAILSAFE mandates it), but worth calling out.

## Independence

Independent of #4 (`feat/tiny-fixes` — the 3 frontmatter/schema fixes coming alongside this one). Either PR can merge first; no ordering requirement.

## Why open as PRs rather than an issue

Every fix in this PR implements a contract that already exists in the repo:

- `templates/FAILSAFE.md` defines the destructive-write policy (this PR makes the scripts honor it)
- The cp950 shim is a Windows-compat fix for the user platform the README's Threads workflow targets
- `build_compiled_memory.sort_key` already uses `parse_iso` — this PR lifts it to a shared helper so ingest paths agree

Treating these as bug fixes rather than feature proposals. Happy to close and split / restructure if the bundling is wrong, or to drop entirely if you prefer to address internally.